### PR TITLE
Deploy to Now using @now/next

### DIFF
--- a/now.json
+++ b/now.json
@@ -6,5 +6,8 @@
       "src": "package.json",
       "use": "@now/next"
     }
+  ],
+  "routes": [
+    { "src": "/p/(?<id>[^/]*)", "dest": "/post?id=$id" }
   ]
 }

--- a/now.json
+++ b/now.json
@@ -1,0 +1,10 @@
+{
+  "version": 2,
+  "name": "hello-next",
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@now/next"
+    }
+  ]
+}


### PR DESCRIPTION
# Deploy a Next.js app to Now using `@now/next`

**Note:** this PR is for [Now 2.0](https://zeit.co/blog/now-2).

## Demo

[![Go to demo](https://img.shields.io/website-up-down-green-red/https/hello-next-13cn8ftp8.now.sh.svg?label=demo)](https://hello-next-13cn8ftp8.now.sh/)

## Steps

1. Create `now.json` file as per **this Pull Request**
  - Create a `builds` entry with `package.json` as source and `@now/next` as builder
  - Add a `routes` entry for each dynamic route
2. Run **`now`**

![image](https://user-images.githubusercontent.com/1246795/50284289-e2c97f00-0458-11e9-8aaf-eb4d55b95900.png)
![image](https://user-images.githubusercontent.com/1246795/50284301-ea892380-0458-11e9-97a9-022a908b0888.png)


## Related

- [Now by Example - Next.js](https://zeit.co/examples/nextjs/)
- [Deployment Configuration (now.json)](https://zeit.co/docs/v2/deployments/configuration/) 
- [Builders Overview](https://zeit.co/docs/v2/deployments/builders/overview/)
